### PR TITLE
fix bugs while using items actions related to food containers

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -5172,7 +5172,7 @@ void player::use( item_location loc )
                used.type->can_use( "CATTLEFODDER" ) ) {
         invoke_item( &used, loc.position() );
 
-    } else if( !used.is_craft() && ( used.is_food() ||
+    } else if( !used.is_craft() && !used.type->has_use() && ( used.is_food() ||
                                      used.is_medication() ||
                                      used.get_contained().is_food() ||
                                      used.get_contained().is_medication() ) ) {


### PR DESCRIPTION
#Summary

SUMMARY: Bugfixes "fix bugs related to interacting with bucket-type containers"

#purpose of change


#describe the solution

add a condition to check that the item being used dosnt have a use_action before directly consuming it.

#Describe alternatives you've considered

None.